### PR TITLE
fix: Improve ScoreCounter responsiveness and positioning for mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ const { title } = Astro.props;
 ---
 <header class="bg-slate-800 text-slate-100 py-6 border-b-4 border-amber-500 shadow-md">
   <div class="container mx-auto px-4 flex flex-col sm:flex-row justify-between items-center">
-    <a href="/test-umh" class="text-slate-100 hover:text-amber-400 transition-colors">
+    <a href="/" class="text-slate-100 hover:text-amber-400 transition-colors">
       <h1 class="text-2xl sm:text-3xl font-bold m-0 text-center sm:text-left">🧪 {title}</h1>
     </a>
     <nav class="mt-4 sm:mt-0">

--- a/src/components/ScoreCounter.astro
+++ b/src/components/ScoreCounter.astro
@@ -16,48 +16,35 @@ const {
   isTestFinished = false,
 } = Astro.props;
 
-// This initial message will be quickly replaced by client-side script logic.
-// However, it's good to have a sensible default structure.
+// These initial values are primarily for SSR before client script takes over.
 let initialCorrect = correctAnswers;
 let initialWrong = wrongAnswers;
 let initialTotal = totalQuestions;
-let initialMessageCorrect = `${initialCorrect}`;
-let initialMessageWrong = `${initialWrong}`;
-let initialMessageTotal = `${initialTotal}`;
 
-if (isTestFinished) {
-  const percentage = totalQuestions > 0 ? Math.round((initialCorrect / totalQuestions) * 100) : 0;
-  // This specific message structure for "finished" will be handled by TestRenderer.astro's script
-  // For now, just ensure the base elements are there.
-}
+// The actual display logic (including "Resultado Final") is handled by TestRenderer.astro's script
 ---
 
-<div id="score-counter-container" class="fixed top-24 left-0 z-40 p-1 md:p-2">
-  <div class="score-card bg-slate-700/80 backdrop-blur-sm text-white shadow-lg rounded-lg p-3 md:p-4 space-y-2 w-auto">
+<div id="score-counter-container" class="fixed top-20 sm:top-24 left-0 z-40 p-1 md:p-2">
+  <div class="score-card bg-slate-700/80 backdrop-blur-sm text-white shadow-lg rounded-lg p-2 sm:p-3 md:p-4 space-y-1 sm:space-y-2 w-auto">
     <div id="score-correct" class="flex items-center">
-      <span class="text-green-400 mr-2">✔️</span>
-      <span class="hidden md:inline mr-1">Correctas:</span>
-      <span class="font-bold">{initialMessageCorrect}</span>
+      <span class="text-green-400 mr-1 sm:mr-2 text-base sm:text-lg">✔️</span>
+      <span class="hidden md:inline mr-1 text-sm sm:text-base">Correctas:</span>
+      <span class="font-bold text-sm sm:text-base">{initialCorrect}</span>
     </div>
     <div id="score-wrong" class="flex items-center">
-      <span class="text-red-400 mr-2">❌</span>
-      <span class="hidden md:inline mr-1">Fallos:</span>
-      <span class="font-bold">{initialMessageWrong}</span>
+      <span class="text-red-400 mr-1 sm:mr-2 text-base sm:text-lg">❌</span>
+      <span class="hidden md:inline mr-1 text-sm sm:text-base">Fallos:</span>
+      <span class="font-bold text-sm sm:text-base">{initialWrong}</span>
     </div>
     <div id="score-total" class="flex items-center">
-      <span class="text-sky-400 mr-2">🎯</span>
-      <span class="hidden md:inline mr-1">Total:</span>
-      <span class="font-bold">{initialMessageTotal}</span>
+      <span class="text-sky-400 mr-1 sm:mr-2 text-base sm:text-lg">🎯</span>
+      <span class="hidden md:inline mr-1 text-sm sm:text-base">Total:</span>
+      <span class="font-bold text-sm sm:text-base">{initialTotal}</span>
     </div>
-    <div id="score-final-percentage" class="text-center font-bold text-amber-400 hidden pt-1">
+    <div id="score-final-percentage" class="text-center font-bold text-amber-400 hidden pt-1 text-sm sm:text-base">
       {/* This will be populated by TestRenderer.astro script when test is finished */}
-      {/* Example: "Resultado: 60%" */}
     </div>
   </div>
 </div>
 
 <!-- No <style> tag needed as all styling is done via Tailwind CSS classes -->
-<!-- Note: The actual dynamic updating of numbers and the final percentage
-     will be handled by the client-side script in TestRenderer.astro.
-     This component primarily sets up the Tailwind structure and initial (server-rendered) values.
--->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,9 +27,13 @@ const siteTitle = "Repositorio de Tests UMH";
 	<body class="flex flex-col h-full bg-slate-100 text-slate-800 antialiased"> {/* Tailwind classes for body styling & sticky footer */}
 		<Header title={siteTitle} />
 		<main class="flex-grow container mx-auto px-4 py-8"> {/* Tailwind for main content area & sticky footer */}
-			{/* Adding some top margin to main content if ScoreCounter is fixed and could overlap */}
-			{/* This might need adjustment based on ScoreCounter's final height & position */}
-			<div class="pt-16 md:pt-12"> {/* Adjust padding if ScoreCounter overlaps content */}
+			{/*
+			  Adjusting top padding to account for ScoreCounter's new responsive top positioning.
+			  ScoreCounter is top-20 (5rem) on smallest, top-24 (6rem) on sm+.
+			  Padding here is slightly more to give breathing room.
+			  pt-24 (6rem) for smallest, pt-28 (7rem) for sm+.
+			*/}
+			<div class="pt-24 sm:pt-28"> {/* Adjust padding if ScoreCounter overlaps content */}
 				<slot />
 			</div>
 		</main>


### PR DESCRIPTION
- Adjusted padding, font sizes, and icon sizes in ScoreCounter.astro to be more compact on smaller mobile screens and scale appropriately on larger screens.
- Implemented responsive `top` positioning for ScoreCounter (top-20 on smallest, sm:top-24 on sm+).
- Updated `padding-top` in Layout.astro (pt-24 on smallest, sm:pt-28 on sm+) to ensure main content is not obscured by the sticky ScoreCounter.