### PR TITLE
Add subtle background image

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import '../styles/global.css'; // Contains @import "tailwindcss"; and minimal ot
 import '@fontsource-variable/dynapuff'; // Font import
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import backgroundImage from '../assets/background.svg';
 
 interface Props {
   title: string;
@@ -24,7 +25,10 @@ const siteTitle = "Repositorio de Tests UMH";
 		<meta name="generator" content={Astro.generator} />
 		<title>{title} | {siteTitle}</title>
 	</head>
-	<body class="flex flex-col h-full bg-slate-100 text-slate-800 antialiased"> {/* Tailwind classes for body styling & sticky footer */}
+        <body
+                class="flex flex-col h-full bg-slate-100 text-slate-800 antialiased"
+                style={`background-image: url(${backgroundImage}); background-size: cover; background-repeat: no-repeat; background-attachment: fixed;`}
+        > {/* Tailwind classes for body styling & sticky footer */}
 		<Header title={siteTitle} />
 		<main class="flex-grow container mx-auto px-4 py-8"> {/* Tailwind for main content area & sticky footer */}
 			<slot />


### PR DESCRIPTION
## Summary
- use existing background.svg in Layout
- apply background image to body element

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_686911082cf08323beb05284e229d173